### PR TITLE
Fixed Coverity error UNINTENDED_INTEGER_DIVISION

### DIFF
--- a/library/src/main/java/com/github/jorgecastillo/clippingtransforms/SquareClippingTransform.java
+++ b/library/src/main/java/com/github/jorgecastillo/clippingtransforms/SquareClippingTransform.java
@@ -38,7 +38,7 @@ public class SquareClippingTransform implements ClippingTransform {
   protected Path buildClippingPath() {
 
     Path squaresPath = new Path();
-    int numSquares = (int) Math.ceil(width / (2 * squareSize));
+    int numSquares = (int) Math.ceil((double) width / (2 * squareSize));
     int startingHeight = height;
     int lowerHeight = startingHeight - squareSize;
     squaresPath.moveTo(0, startingHeight);


### PR DESCRIPTION
Coverity Scan found an error:
```
CID 105392 (#1 of 1): Result is not floating-point
(UNINTENDED_INTEGER_DIVISION)integer_division: Dividing integer
expressions width and 2 * squareSize, and then converting the integer
quotient to type double. Any remainder, or fractional part of the
quotient, is ignored.
```

The solution is simply to cast one of the arguments to double. This
commit does that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jorgecastilloprz/androidfillableloaders/8)
<!-- Reviewable:end -->
