### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Add it to your project
 If you are working with gradle, add the dependency to your build.gradle file:
 ```groovy
 dependencies{
-    compile 'com.github.jorgecastilloprz:fillableloaders:1.03@aar'
+    implementation 'com.github.jorgecastilloprz:fillableloaders:1.03@aar'
 }
 ```
 if you are working with maven, do it into your pom.xml


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jorgecastilloprz/androidfillableloaders/21)
<!-- Reviewable:end -->
